### PR TITLE
Improve unsafe Sdt::write() functionality

### DIFF
--- a/src/sdt.rs
+++ b/src/sdt.rs
@@ -7,9 +7,10 @@ extern crate alloc;
 
 use crate::{Aml, AmlSink};
 use alloc::vec::Vec;
+use zerocopy::AsBytes;
 
 #[repr(packed)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, AsBytes)]
 pub struct GenericAddress {
     pub address_space_id: u8,
     pub register_bit_width: u8,


### PR DESCRIPTION
- sdt: Derive zerocopy::AsBytes for GenericAddress
- sdt: Replace unsafe Sdt::write() logic
