### PR TITLE
build: Bump version of zerocopy dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-zerocopy = "0.6.1"
+zerocopy = { version = "0.7.1", features = ["derive"] }


### PR DESCRIPTION
This new version also requires the use of additional feature to access
the #[derive(AsBytes)] macro

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
