### PR TITLE
acpi_tables: Fix clippy warnings related to no_std and prelude imports

### DIFF
--- a/src/aml.rs
+++ b/src/aml.rs
@@ -1698,7 +1698,7 @@ impl<'a> Aml for PowerResource<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::vec;
+    use alloc::borrow::ToOwned;
 
     #[test]
     fn test_device() {

--- a/src/bert.rs
+++ b/src/bert.rs
@@ -63,6 +63,7 @@ aml_as_bytes!(BERT);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_bert() {

--- a/src/fadt.rs
+++ b/src/fadt.rs
@@ -247,6 +247,7 @@ impl FADTBuilder {
 mod test {
     use super::{FADTBuilder, Flags, PmProfile};
     use crate::Aml;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_fadt() {

--- a/src/hmat.rs
+++ b/src/hmat.rs
@@ -357,7 +357,6 @@ impl Aml for MemorySideCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Aml;
 
     fn check_checksum(hmat: &HMAT) {
         let mut bytes = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //
 
 #![crate_type = "staticlib"]
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
 //! ACPI table generation.
 

--- a/src/madt.rs
+++ b/src/madt.rs
@@ -649,7 +649,6 @@ aml_as_bytes!(PLIC);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Aml;
 
     fn check_checksum(madt: &MADT) {
         let mut bytes = Vec::new();

--- a/src/rhct.rs
+++ b/src/rhct.rs
@@ -335,7 +335,6 @@ impl Aml for MmuNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Aml;
 
     #[test]
     fn test_rhct() {

--- a/src/rimt.rs
+++ b/src/rimt.rs
@@ -493,6 +493,7 @@ impl Aml for Platform {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     fn rimt() -> RIMT {
         RIMT::new(*b"FOOBAR", *b"CAFEDEAD", 0xdead_beef)

--- a/src/spcr.rs
+++ b/src/spcr.rs
@@ -168,6 +168,7 @@ impl SerialPortInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_sbi_spcr() {

--- a/src/tpm2.rs
+++ b/src/tpm2.rs
@@ -306,6 +306,7 @@ impl Aml for Tpm2 {
 mod tests {
     use super::*;
     use crate::gas;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_client() {

--- a/src/xsdt.rs
+++ b/src/xsdt.rs
@@ -74,6 +74,7 @@ impl Aml for XSDT {
 mod tests {
     use super::XSDT;
     use crate::Aml;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_xsdt() {


### PR DESCRIPTION
See - https://github.com/rust-lang/rust/issues/121362 the recommendation
for how for no_std libraries has changed.

To avoid warnings around unncessary imports (due to the prelude when
compiling tests) make the tests also no_std and explicitly import the
require test dependencies.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
