### PR TITLE
aml: Fix clippy warning related to legacy max_value() method

### DIFF
--- a/src/aml.rs
+++ b/src/aml.rs
@@ -191,7 +191,7 @@ pub type Word = u16;
 
 impl Aml for Word {
     fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
-        if *self <= Byte::max_value().into() {
+        if *self <= Byte::MAX.into() {
             (*self as Byte).to_aml_bytes(sink);
         } else {
             sink.byte(WORDPREFIX);
@@ -204,7 +204,7 @@ pub type DWord = u32;
 
 impl Aml for DWord {
     fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
-        if *self <= Word::max_value().into() {
+        if *self <= Word::MAX.into() {
             (*self as Word).to_aml_bytes(sink);
         } else {
             sink.byte(DWORDPREFIX);
@@ -217,7 +217,7 @@ pub type QWord = u64;
 
 impl Aml for QWord {
     fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
-        if *self <= DWord::max_value().into() {
+        if *self <= DWord::MAX.into() {
             (*self as DWord).to_aml_bytes(sink);
         } else {
             sink.byte(QWORDPREFIX);


### PR DESCRIPTION
::max_value() should be replaced by ::MAX

warning: usage of a legacy numeric method
   --> src/aml.rs:194:27
    |
194 |         if *self <= Byte::max_value().into() {
    |                           ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
    = note: `#[warn(clippy::legacy_numeric_constants)]` on by default
help: use the associated constant instead
    |
194 |         if *self <= Byte::MAX.into() {
    |                           ~~~

warning: usage of a legacy numeric method
   --> src/aml.rs:207:27
    |
207 |         if *self <= Word::max_value().into() {
    |                           ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
help: use the associated constant instead
    |
207 |         if *self <= Word::MAX.into() {
    |                           ~~~

warning: usage of a legacy numeric method
   --> src/aml.rs:220:28
    |
220 |         if *self <= DWord::max_value().into() {
    |                            ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
help: use the associated constant instead
    |
220 |         if *self <= DWord::MAX.into() {
    |                            ~~~

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>


