### PR TITLE
pptt: fix revision number

### DIFF
--- a/src/pptt.rs
+++ b/src/pptt.rs
@@ -57,7 +57,7 @@ impl PPTT {
         let header = TableHeader {
             signature: *b"PPTT",
             length: (TableHeader::len() as u32).into(),
-            revision: 1,
+            revision: 3,
             checksum: 0,
             oem_id,
             oem_table_id,


### PR DESCRIPTION
### Summary of the PR

The revision number is hardcoded to 1 but it is incorrect. The table produced by this crate actually conforms to revision 3 (because the cache ID field is present which was introduced in rev 3).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
