### PR TITLE
madt: add support for table flags

### DIFF
--- a/src/madt.rs
+++ b/src/madt.rs
@@ -17,6 +17,11 @@ type U16 = byteorder::U16<LE>;
 type U32 = byteorder::U32<LE>;
 type U64 = byteorder::U64<LE>;
 
+#[repr(u32)]
+enum MadtFlags {
+    PcAtCompat = 1 << 0,
+}
+
 #[repr(u8)]
 enum MadtStructureType {
     ProcessorLocalApic = 0x0,
@@ -96,6 +101,20 @@ impl MADT {
             structures: Vec::new(),
             has_imsic: false,
         }
+    }
+
+    pub fn pc_at_compat(mut self) -> Self {
+        self.set_flag(MadtFlags::PcAtCompat);
+        self
+    }
+
+    fn set_flag(&mut self, flag: MadtFlags) {
+        let old_flags = self.header.flags.get();
+        self.header.flags |= flag as u32;
+
+        self.checksum.delete(old_flags.as_bytes());
+        self.checksum.append(self.header.flags.as_bytes());
+        self.header.table_header.checksum = self.checksum.value();
     }
 
     fn update_header(&mut self, data: &[u8]) {
@@ -671,7 +690,8 @@ mod tests {
             *b"DECAFCOF",
             0xdead_beef,
             LocalInterruptController::Riscv,
-        );
+        )
+        .pc_at_compat();
         check_checksum(&madt);
         assert_eq!(Header::len(), get_size(&madt));
     }


### PR DESCRIPTION
Add support for MADT table flags. Currently the ACPI spec only defines the `PCAT_COMPAT` flag.

### Summary of the PR

[Table 5.20](https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#multiple-apic-flags) of the ACPI spec. defines the flags that can be set for the MADT table, but currently it's not possible to set them. This PR adds support for defining MADT table flags (currently only `PCAT_COMPAT` exists).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.

Note: I'm not sure where to find the `CHANGELOG.md` file.