### PR TITLE
aml: support multiple interrupt numbers

### DIFF
--- a/src/aml.rs
+++ b/src/aml.rs
@@ -723,7 +723,7 @@ pub struct Interrupt {
     edge_triggered: bool,
     active_low: bool,
     shared: bool,
-    number: u32,
+    numbers: Vec<u32>,
 }
 
 impl Interrupt {
@@ -733,14 +733,14 @@ impl Interrupt {
         edge_triggered: bool,
         active_low: bool,
         shared: bool,
-        number: u32,
+        numbers: Vec<u32>,
     ) -> Self {
         Interrupt {
             consumer,
             edge_triggered,
             active_low,
             shared,
-            number,
+            numbers,
         }
     }
 }
@@ -748,14 +748,14 @@ impl Interrupt {
 impl Aml for Interrupt {
     fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
         sink.byte(EXTIRQDESC); /* Extended IRQ Descriptor */
-        sink.word(6);
+        sink.word(2 + 4 * self.numbers.len() as u16);
         let flags = ((self.shared as u8) << 3)
             | ((self.active_low as u8) << 2)
             | ((self.edge_triggered as u8) << 1)
             | self.consumer as u8;
         sink.byte(flags);
-        sink.byte(1); /* count */
-        sink.dword(self.number);
+        sink.byte(self.numbers.len() as u8); /* count */
+        self.numbers.iter().for_each(|n| sink.dword(*n));
     }
 }
 
@@ -1698,7 +1698,7 @@ mod tests {
                 &Name::new(
                     "_CRS".into(),
                     &ResourceTemplate::new(vec![
-                        &Interrupt::new(true, true, false, false, 4),
+                        &Interrupt::new(true, true, false, false, vec![4]),
                         &IO::new(0x3f8, 0x3f8, 0, 0x8),
                     ]),
                 ),
@@ -1928,14 +1928,15 @@ mod tests {
 
         */
         let interrupt_io_data = [
-            0x08, 0x5F, 0x43, 0x52, 0x53, 0x11, 0x16, 0x0A, 0x13, 0x89, 0x06, 0x00, 0x03, 0x01,
-            0x04, 0x00, 0x00, 0x00, 0x47, 0x01, 0xF8, 0x03, 0xF8, 0x03, 0x00, 0x08, 0x79, 0x00,
+            0x08, 0x5F, 0x43, 0x52, 0x53, 0x11, 0x1A, 0x0A, 0x17, 0x89, 0x0A, 0x00, 0x03, 0x02,
+            0x04, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x47, 0x01, 0xF8, 0x03, 0xF8, 0x03,
+            0x00, 0x08, 0x79, 0x00,
         ];
         aml.clear();
         Name::new(
             "_CRS".into(),
             &ResourceTemplate::new(vec![
-                &Interrupt::new(true, true, false, false, 4),
+                &Interrupt::new(true, true, false, false, vec![4, 5]),
                 &IO::new(0x3f8, 0x3f8, 0, 0x8),
             ]),
         )


### PR DESCRIPTION
### Summary of the PR

The [ACPI spec](https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/06_Device_Configuration/Device_Configuration.html#extended-interrupt-descriptor) allows multiple interrupt numbers to be specified in the extended interrupt descriptor.
 
This is breaking change, so it probably needs further consideration before merge. A few options to avoid breaking the API include:
1. create a separate struct to generate `Interrupt`s with multiple numbers.
1. keep the constructor the same, but add a new method to include additional numbers.

Let me know how what would be preference and I can adjust the PR.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
